### PR TITLE
Update Columbia University enrollment and simplify CV

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,7 +24,7 @@ author:
   avatar           : "IMG_1862.JPG"
   name             : "Jiayi (Marco) Chen"
   pronouns         : "He/His" # example: "she/her"  
-  bio: "Incoming Master @ Cal<br>Undergrad @ Soochow University"
+  bio: "M.A. Statistics (Theory & Methods Honors) @ Columbia University<br>B.S. Psychology & B.B.A. Accounting @ Soochow University"
   location         : "Suzhou"
   employer         : "BOCIM"
   uri              : # URL

--- a/_config.yml
+++ b/_config.yml
@@ -24,7 +24,7 @@ author:
   avatar           : "IMG_1862.JPG"
   name             : "Jiayi (Marco) Chen"
   pronouns         : "He/His" # example: "she/her"  
-  bio: "M.A. Statistics (Theory & Methods Honors) @ Columbia University<br>B.S. Psychology & B.B.A. Accounting @ Soochow University"
+  bio: "M.A. Statistics (Theory & Methods Honors) @ Columbia University<br /><br />B.S. Psychology & B.B.A. Accounting @ Soochow University"
   location         : "Suzhou"
   employer         : "BOCIM"
   uri              : # URL

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -7,6 +7,6 @@ redirect_from:
   - /about.html
 ---
 
-Jiayi Chen is a senior student at Soochow University, majoring in Accounting and minoring in Applied Psychology. He developed a strong interest in data analytics and operations research during his undergraduate studies. In Spring 2024, he joined the University of California, Berkeley as a visiting student at the IEOR Department and Haas Business School.
+Jiayi Chen is an M.A. Statistics (Theory and Methods Honors Track) student at Columbia University. He previously majored in Accounting and minored in Applied Psychology at Soochow University, where he developed a strong interest in data analytics and operations research. In Spring 2024, he joined the University of California, Berkeley as a visiting student at the IEOR Department and Haas Business School.
 
 Jiayi has interned at Deloitte as a data analyst and at Bank of China Investment Management (BOCIM) as a quantitative research intern. His career goal is to integrate quantitative analysis with psychological theories, focusing on applications in healthcare and finance. Jiayi aims to provide innovative, data-driven solutions to complex challenges in these fields.

--- a/_pages/cv.md
+++ b/_pages/cv.md
@@ -21,33 +21,30 @@ redirect_from:
 
 <h2 id="education">Education</h2>
 
+### **Columbia University**
+**M.A. Statistics (Theory and Methods Honors Track)**
+Enrolled in the Theory and Methods Honors Track to deepen training in statistical theory, methodology, and research practice.
+
 ### **University of California, Berkeley**
-**Visiting Student** | January 2024 – May 2024
-- Departments: Industrial Engineering and Operations Research (IEOR) and Haas School of Business.
-- Focus: Data analytics, operations research, and business decision-making.
+**Visiting Student** | January 2024 – May 2024  
+Concentrated on data analytics and operations research coursework within the IEOR Department and Haas School of Business.
 
 ### **Soochow University**
-**Bachelor of Science (B.S.) in Applied Psychology** | September 2022 – June 2025
-- Relevant coursework: Behavioral Psychology, Statistical Analysis, Cognitive Science.
+**Bachelor of Science (B.S.) in Applied Psychology** | September 2022 – June 2025  
+Completed behavioral psychology, statistical analysis, and cognitive science coursework.
 
-**Bachelor of Business Administration (B.BA.) in Accounting** | September 2021 – June 2025
-- Relevant coursework: Financial Accounting, Managerial Accounting, Auditing, Corporate Finance.
-- Honors: Innovation and Entrepreneurship Scholarship (Outstanding Prize,0.5%,2023).
+**Bachelor of Business Administration (B.BA.) in Accounting** | September 2021 – June 2025  
+Studied financial and managerial accounting, auditing, and corporate finance, earning the 2023 Innovation and Entrepreneurship Scholarship (Outstanding Prize, 0.5%).
 
 <hr>
 
 <h2 id="work-experience">Work Experience</h2>
 
 ### **Bank of China Investment Management Co., Ltd. (BOCIM)**
-**Quantitative Research Intern** | Summer 2024
-- Developed alpha-seeking strategies using **Genetic Algorithms** and replicated analytical reports for performance insights.
-- Constructed predictive models leveraging **statistical methods** and **ML/DL techniques** for financial data analysis.
-- Conducted backtesting with an average **RankIC** exceeding 0.1, validating model robustness and predictive power.
+**Quantitative Research Intern** | Summer 2024  
+Developed genetic algorithm-based alpha strategies, built statistical and machine learning models for financial data, and validated performance through backtesting with RankIC above 0.1.
 
 ### **Deloitte iBond (Shanghai) Co., Ltd.**
-**Data Analyst Intern** | Fall 2024
-- Developed a **Bond Risk Early Warning Model** integrating **sentiment analysis**, **market data**, and **fundamental indicators** to evaluate stress indices and default risks of bond issuers.
-- Employed **Python** for real-time data scraping and processing, dynamically updating risk scores using decay algorithms.
-- Designed a **network model** to analyze risk transmission paths and utilized an **SIS model** to capture credit risk contagion among enterprises.
-- Assisted in transitioning from legacy systems to advanced risk assessment models.
+**Data Analyst Intern** | Fall 2024  
+Built a bond risk early warning model that combined sentiment, market, and network analyses while modernizing pipelines for real-time credit risk assessment.
 


### PR DESCRIPTION
## Summary
- update the sidebar bio and homepage introduction to reflect enrollment in Columbia University's M.A. Statistics (Theory and Methods Honors Track)
- streamline the CV page by condensing each entry to single-sentence descriptions and adding the new graduate program

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c85c793b9c8325a76cfb186370edc5