### PR TITLE
Restyle home page with wabi-sabi aesthetic

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -2,12 +2,59 @@
 permalink: /
 title: "About"
 author_profile: true
-redirect_from: 
+redirect_from:
   - /about/
   - /about.html
 ---
 
+<div class="wabi-hero">
+  <p class="wabi-hero__eyebrow">Quiet curiosity, deliberate craft</p>
+  <h1 class="wabi-hero__title">Hi, I'm Jiayi (Marco) Chen.</h1>
+  <p class="wabi-hero__subtitle">
+    I read messy, real-world data with the same patience I bring to the slow
+    brewing of tea&mdash;one careful observation at a time.
+  </p>
+</div>
 
-Jiayi Chen is an M.A. Statistics (Theory and Methods Honors Track) student at Columbia University. He previously majored in Accounting and minored in Applied Psychology at Soochow University, where he developed a strong interest in data analytics and operations research. In Spring 2024, he joined the University of California, Berkeley as a visiting student at the IEOR Department and Haas Business School.
+<section class="wabi-section">
+  <h2>Focus</h2>
+  <ul class="wabi-list">
+    <li><strong>Fields:</strong> Statistical theory, operations research, and behavioral insights.</li>
+    <li><strong>Interests:</strong> Applying quantitative methods to healthcare and finance questions that benefit from empathy as much as rigor.</li>
+    <li><strong>Methods:</strong> Stochastic modeling, data storytelling, and collaborative experimentation.</li>
+  </ul>
+</section>
 
-Jiayi has interned at Deloitte as a data analyst and at Bank of China Investment Management (BOCIM) as a quantitative research intern. His career goal is to integrate quantitative analysis with psychological theories, focusing on applications in healthcare and finance. Jiayi aims to provide innovative, data-driven solutions to complex challenges in these fields.
+<section class="wabi-section">
+  <h2>Now</h2>
+  <p>
+    I'm an M.A. Statistics (Theory and Methods Honors Track) student at Columbia University.
+    You can usually find me exploring how thoughtfully designed analyses can support kinder, smarter decision-making.
+  </p>
+</section>
+
+<section class="wabi-section wabi-section--paired">
+  <div>
+    <h3>Recent Chapters</h3>
+    <ul class="wabi-list">
+      <li>Visiting student at UC Berkeley's IEOR Department and Haas School of Business in Spring 2024.</li>
+      <li>Interned as a data analyst at Deloitte.</li>
+      <li>Quantitative research intern at Bank of China Investment Management (BOCIM).</li>
+    </ul>
+  </div>
+  <div>
+    <h3>Earlier Roots</h3>
+    <p>
+      I majored in Accounting and minored in Applied Psychology at Soochow University, where I began weaving
+      together numbers, human behavior, and operational thinking.
+    </p>
+  </div>
+</section>
+
+<section class="wabi-section">
+  <h2>What guides my work</h2>
+  <p class="wabi-note">
+    I'm working toward a career that fuses quantitative analysis with psychological theory.
+    The goal is to surface quiet patterns, reveal practical stories, and offer innovations that feel as considerate as they are data-driven.
+  </p>
+</section>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -39,3 +39,190 @@
 @import "vendor/font-awesome/brands";
 @import "vendor/magnific-popup/magnific-popup";
 @import "print";
+
+@import url('https://fonts.googleapis.com/css2?family=Zen+Antique+Soft&family=Work+Sans:wght@300;400;500;600&display=swap');
+
+:root {
+  --wabi-background: #f4f0e8;
+  --wabi-paper: rgba(255, 255, 255, 0.75);
+  --wabi-ink: #3a3632;
+  --wabi-ink-soft: #5f5751;
+  --wabi-accent: #9c7b5c;
+  --wabi-stone: rgba(70, 62, 55, 0.08);
+  --wabi-shadow: 0 18px 40px rgba(60, 52, 44, 0.14);
+}
+
+body {
+  background-color: var(--wabi-background);
+  background-image: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.6), transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(201, 185, 167, 0.18), transparent 55%),
+    linear-gradient(120deg, rgba(232, 220, 203, 0.4), rgba(221, 208, 190, 0.25));
+  color: var(--wabi-ink);
+  font-family: 'Work Sans', 'Helvetica Neue', Arial, sans-serif;
+}
+
+.page__content {
+  background: var(--wabi-paper);
+  backdrop-filter: blur(6px);
+  border-radius: 22px;
+  box-shadow: var(--wabi-shadow);
+  padding: 3rem clamp(1.5rem, 5vw, 4rem);
+  border: 1px solid var(--wabi-stone);
+}
+
+.page__content h1,
+.page__content h2,
+.page__content h3,
+.page__content h4,
+.page__content h5,
+.page__content h6 {
+  font-family: 'Zen Antique Soft', 'Times New Roman', serif;
+  color: var(--wabi-ink);
+  letter-spacing: 0.02em;
+}
+
+.page__content a {
+  color: var(--wabi-accent);
+  text-decoration-color: rgba(156, 123, 92, 0.4);
+  transition: color 180ms ease, text-decoration-color 180ms ease;
+}
+
+.page__content a:hover,
+.page__content a:focus {
+  color: darken(#9c7b5c, 8%);
+  text-decoration-color: rgba(156, 123, 92, 0.8);
+}
+
+.wabi-hero {
+  position: relative;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  margin-bottom: clamp(2rem, 6vw, 4rem);
+  border-radius: 18px;
+  background: linear-gradient(160deg, rgba(248, 242, 233, 0.85), rgba(230, 219, 205, 0.65));
+  border: 1px solid rgba(156, 123, 92, 0.18);
+  box-shadow: 0 24px 50px rgba(68, 55, 45, 0.12);
+  overflow: hidden;
+}
+
+.wabi-hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: url('data:image/svg+xml,%3Csvg width="300" height="300" viewBox="0 0 300 300" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="M150 0C200 60 300 80 300 150C300 220 200 240 150 300C100 240 0 220 0 150C0 80 100 60 150 0Z" fill="rgba(255,255,255,0.2)"/%3E%3C/svg%3E');
+  background-size: cover;
+  opacity: 0.35;
+  mix-blend-mode: soft-light;
+  pointer-events: none;
+}
+
+.wabi-hero > * {
+  position: relative;
+  z-index: 1;
+}
+
+.wabi-hero__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  font-size: 0.75rem;
+  color: var(--wabi-ink-soft);
+  margin-bottom: 0.75rem;
+}
+
+.wabi-hero__title {
+  font-size: clamp(2.2rem, 5vw, 3.4rem);
+  margin-bottom: 1rem;
+}
+
+.wabi-hero__subtitle {
+  max-width: 32rem;
+  font-size: clamp(1.05rem, 2.6vw, 1.3rem);
+  line-height: 1.7;
+  color: var(--wabi-ink-soft);
+}
+
+.wabi-section {
+  margin-bottom: clamp(2.2rem, 5vw, 3.5rem);
+}
+
+.wabi-section h2,
+.wabi-section h3 {
+  display: inline-block;
+  padding-bottom: 0.3rem;
+  border-bottom: 2px solid rgba(156, 123, 92, 0.28);
+}
+
+.wabi-section p,
+.wabi-section li {
+  color: var(--wabi-ink-soft);
+  line-height: 1.8;
+}
+
+.wabi-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.wabi-list li {
+  position: relative;
+  padding-left: 1.75rem;
+}
+
+.wabi-list li::before {
+  content: '';
+  position: absolute;
+  top: 0.55em;
+  left: 0.35rem;
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 50%;
+  background: var(--wabi-accent);
+  opacity: 0.5;
+}
+
+.wabi-section--paired {
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 3rem);
+}
+
+@media (min-width: 768px) {
+  .wabi-section--paired {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.wabi-note {
+  background: rgba(255, 255, 255, 0.68);
+  border-left: 4px solid rgba(156, 123, 92, 0.65);
+  padding: 1.75rem clamp(1.25rem, 3vw, 2.4rem);
+  border-radius: 14px;
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.08);
+}
+
+.site-title,
+.site-title:visited {
+  font-family: 'Zen Antique Soft', 'Times New Roman', serif;
+  letter-spacing: 0.08em;
+}
+
+.site-title:hover,
+.site-title:focus {
+  color: var(--wabi-accent) !important;
+}
+
+.btn,
+.page__content .btn {
+  border-radius: 999px;
+  background: var(--wabi-accent);
+  border: none;
+  color: #fdfbf7;
+  box-shadow: 0 12px 28px rgba(156, 123, 92, 0.25);
+}
+
+.btn:hover,
+.btn:focus {
+  background: darken(#9c7b5c, 6%);
+}
+


### PR DESCRIPTION
## Summary
- rewrite the home page content into wabi-sabi inspired sections and narrative blocks
- layer wabi-sabi typography, palette, and layout treatments into the main stylesheet for a softer visual tone

## Testing
- bundle exec jekyll build *(fails: `jekyll` executable missing because gems could not be installed)*
- bundle install *(fails: rubygems.org returns 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd40eeaf508325bb8bc52f7b5fdca8